### PR TITLE
Meeting2 fixes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+source = src
+omit = src/example.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Click==7.0
+coverage==5.0.3
 Flask==1.1.1
 Flask-SQLAlchemy==2.4.1
 itsdangerous==1.1.0

--- a/src/example.py
+++ b/src/example.py
@@ -32,7 +32,7 @@ def first_example():
     tournament = Tournament(name="Chess Tournament 1", status=1, created_at=func.now())
 
     #Initialize a game and add the players (created_at defaults to func.now() but is here as an example)
-    chess_game = Game(status=1, game_type=game_type, host=player_1, tournament=tournament, game_token="chess_token", created_at=func.now())
+    chess_game = Game(accessname="testgame1" ,status=1, game_type=game_type, host=player_1, tournament=tournament, game_token="chess_token", created_at=func.now())
 
     #Initial player scores, the points are optional
     player_1_score = PlayerScore(player=player_1, game=chess_game)
@@ -75,7 +75,7 @@ def second_example():
     #No tournament this time as it is optional
 
     #Initialize a game and add the players, in this example game has already ended
-    hearts_game = Game(status=0, game_type=game_type, host=player_1, game_token="hearts_token", created_at=datetime.datetime.now()-datetime.timedelta(days=5), finished_at=datetime.datetime.now()-datetime.timedelta(days=2))
+    hearts_game = Game(accessname="gameofhearts", status=0, game_type=game_type, host=player_1, game_token="hearts_token", created_at=datetime.datetime.now()-datetime.timedelta(days=5), finished_at=datetime.datetime.now()-datetime.timedelta(days=2))
 
     #Player scores, this time they have scores
     player_1_score = PlayerScore(player=player_1, score=22, game=hearts_game)

--- a/src/orm_models.py
+++ b/src/orm_models.py
@@ -6,6 +6,7 @@ from sqlalchemy.sql import func
 #Represents a single match
 class Game(db.Model):
     id = db.Column(db.Integer, primary_key=True)
+    accessname = db.Column(db.String(255), unique=True, nullable=False)
     status = db.Column(db.Integer, default=0) #1 if active, 0 if not active
     game_type_id = db.Column(db.Integer, db.ForeignKey("game_type.id", ondelete="SET NULL"))
     host_id = db.Column(db.Integer, db.ForeignKey("player.id", ondelete="SET NULL")) #One of the players has to be a host

--- a/src/orm_models.py
+++ b/src/orm_models.py
@@ -17,24 +17,26 @@ class Game(db.Model):
     #Relationships to other models
     game_type = db.relationship("GameType", back_populates="game")
     host = db.relationship("Player")
-    scores = db.relationship("PlayerScore", back_populates="game")
+    scores = db.relationship("PlayerScore", cascade="all, delete-orphan", back_populates="game")
     tournament = db.relationship("Tournament", back_populates="game")
 
 #Represents a single player, only name defined 
 class Player(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.VARCHAR(255), nullable=False, unique=True, index=True)
+    score = db.relationship("PlayerScore", cascade="all, delete-orphan", back_populates="player")
+    lboard = db.relationship("Leaderboard", cascade="all, delete-orphan", back_populates="player")
 
 #The score of a player in a match
 #This also connects players and games to each other
 class PlayerScore(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    player_id = db.Column(db.Integer, db.ForeignKey("player.id"), nullable=False)
+    player_id = db.Column(db.Integer, db.ForeignKey("player.id", ondelete="CASCADE"), nullable=False)
     score = db.Column(db.Float(24))
-    game_id = db.Column(db.Integer, db.ForeignKey("game.id"), nullable=False)
+    game_id = db.Column(db.Integer, db.ForeignKey("game.id", ondelete="CASCADE"), nullable=False)
 
     #Relationships to other models
-    player = db.relationship("Player")
+    player = db.relationship("Player", back_populates="score")
     game = db.relationship("Game", back_populates="scores")
 
 #A type of game, used to differentiate different kind of games from each other 
@@ -46,6 +48,7 @@ class GameType(db.Model):
 
     #Relationships to other models
     game = db.relationship("Game", back_populates="game_type")
+    lboard = db.relationship("Leaderboard", cascade="all, delete-orphan", back_populates="game_type")
 
 #Used to track how well a player has done in games of different game types
 class Leaderboard(db.Model):
@@ -56,8 +59,8 @@ class Leaderboard(db.Model):
     losses = db.Column(db.Integer, nullable=False)
 
     #Relationships to other models
-    game_type = db.relationship("GameType")
-    player = db.relationship("Player")
+    game_type = db.relationship("GameType", back_populates="lboard")
+    player = db.relationship("Player", back_populates="lboard")
 
     #every player_id and game_type_id combination is unique
     __table__args__ = (db.UniqueConstraint('player_id', 'game_type_id', '_player_id_game_type_id_uc'),)

--- a/src/orm_models.py
+++ b/src/orm_models.py
@@ -17,7 +17,7 @@ class Game(db.Model):
 
     #Relationships to other models
     game_type = db.relationship("GameType", back_populates="game")
-    host = db.relationship("Player")
+    host = db.relationship("Player", back_populates="game")
     scores = db.relationship("PlayerScore", cascade="all, delete-orphan", back_populates="game")
     tournament = db.relationship("Tournament", back_populates="game")
 
@@ -27,6 +27,7 @@ class Player(db.Model):
     name = db.Column(db.VARCHAR(255), nullable=False, unique=True, index=True)
     score = db.relationship("PlayerScore", cascade="all, delete-orphan", back_populates="player")
     lboard = db.relationship("Leaderboard", cascade="all, delete-orphan", back_populates="player")
+    game = db.relationship("Game", back_populates="host")
 
 #The score of a player in a match
 #This also connects players and games to each other

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -40,7 +40,7 @@ class TestGame(unittest.TestCase):
 
     def testCreateGameWithoutGameTypeAllowed(self):
         host = Player(name="Test player")
-        game = Game(host=host, game_token="12345")
+        game = Game(accessname="notypegame", host=host, game_token="12345")
 
         db.session.add(host)
         db.session.add(game)
@@ -53,7 +53,7 @@ class TestGame(unittest.TestCase):
 
     def testCreateGameWithoutHostAllowed(self):
         game_type = GameType(name="chess")
-        game = Game(game_type = game_type, game_token="12345")
+        game = Game(accessname="hostlessgame", game_type = game_type, game_token="12345")
 
         db.session.add(game_type)
         db.session.add(game)
@@ -105,7 +105,7 @@ class TestGame(unittest.TestCase):
         game_type = GameType(name="chess", max_players=3)
         host = Player(name="Test player")
 
-        game = Game(game_type=game_type, host=host, game_token="test")
+        game = Game(accessname="basicgame", game_type=game_type, host=host, game_token="test")
 
         db.session.add(game_type)
         db.session.add(host)

--- a/test/test_leaderboard.py
+++ b/test/test_leaderboard.py
@@ -96,6 +96,42 @@ class TestLeaderboard(unittest.TestCase):
         with self.assertRaises(orm.exc.FlushError):
             db.session.commit()
 
+    def testGameTypeDeletionDeletesLeaderboard(self):
+        game_type = self.create_game_type()
+        player = self.create_player("Alice")
+
+        leaderboard = Leaderboard(game_type = game_type, player=player, wins=5, losses=5)
+
+        db.session.add(leaderboard)
+        db.session.commit()
+
+        assert GameType.query.count() == 1
+        assert Leaderboard.query.count() == 1
+
+        db.session.delete(game_type)
+        db.session.commit()
+
+        assert GameType.query.count() == 0
+        assert Leaderboard.query.count() == 0
+        
+    def testPlayerDeletionDeletesLeaderboard(self):
+        game_type_2 = self.create_game_type()
+        player_2 = self.create_player("Bob")
+
+        leaderboard_2 = Leaderboard(game_type = game_type_2, player=player_2, wins=5, losses=5)
+
+        db.session.add(leaderboard_2)
+        db.session.commit()
+        assert Player.query.count() == 1
+        assert Leaderboard.query.count() == 1
+
+        db.session.delete(player_2)
+        db.session.commit()
+
+        assert Player.query.count() == 0
+        assert Leaderboard.query.count() == 0
+
+
     def create_game_type(self):
         game_type = GameType(name="chess", max_players=3)
         db.session.add(game_type)

--- a/test/test_player_score.py
+++ b/test/test_player_score.py
@@ -71,7 +71,7 @@ class TestPlayerScore(unittest.TestCase):
     def create_basic_game(self):
         game_type = GameType(name="chess", max_players=3)
         host = Player(name="Test player")
-        game = Game(game_type=game_type, host=host, game_token="test")
+        game = Game(accessname="basicgame", game_type=game_type, host=host, game_token="test")
 
         db.session.add(game_type)
         db.session.add(host)

--- a/test/test_player_score.py
+++ b/test/test_player_score.py
@@ -18,7 +18,7 @@ class TestPlayerScore(unittest.TestCase):
         db.drop_all()
         self.app_context.pop()
 
-    def testCreateAndDeleteValidPlayer(self):
+    def testCreateAndDeleteValidPlayerScore(self):
         player = self.create_player()
         game = self.create_basic_game()
         player_score = PlayerScore(game=game, player=player)
@@ -67,6 +67,42 @@ class TestPlayerScore(unittest.TestCase):
 
         with self.assertRaises(orm.exc.FlushError):
             db.session.commit()
+
+    def testPlayerDeletionDeletesPlayerScore(self):
+        game = self.create_basic_game()
+
+        player_1 = self.create_player("Player 1")
+        player_score_1 = PlayerScore(player=player_1, game=game)
+        db.session.add(player_1)
+        db.session.add(player_score_1)
+        db.session.commit()
+
+        assert PlayerScore.query.count() == 1
+        assert Player.query.count() == 2
+
+        db.session.delete(player_1)
+        db.session.commit()
+
+        assert Player.query.count() == 1
+        assert PlayerScore.query.count() == 0
+        
+    def testGameDeletionDeletesPlayerScore(self):
+        game = self.create_basic_game()
+
+        player_1 = self.create_player("Player 1")
+        player_score_1 = PlayerScore(player=player_1, game=game)
+        db.session.add(player_1)
+        db.session.add(player_score_1)
+        db.session.commit()
+
+        assert Game.query.count() == 1
+        assert PlayerScore.query.count() == 1
+
+        db.session.delete(game)
+        db.session.commit()
+
+        assert Game.query.count() == 0
+        assert PlayerScore.query.count() == 0
 
     def create_basic_game(self):
         game_type = GameType(name="chess", max_players=3)


### PR DESCRIPTION
This pull request addressess all the action points in meeting 2. 

Model foreign key deletion behaviors were fixed, added to Game model a special name (accessname) for accessing the game.

Added unit tests that test the deletion of foreign key items in the tables and that the behavior related to the deletion is correct.  

Unit tests can be run now with "coverage run -m unittest -v && coverage report" to get more verbose output and coverage report.

